### PR TITLE
changing the url to default so people can open project

### DIFF
--- a/Office365Groups.Connector/Office365Groups.Connector.csproj
+++ b/Office365Groups.Connector/Office365Groups.Connector.csproj
@@ -263,7 +263,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>1632</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>https://vrdmn.local.net:44301/</IISUrl>
+          <IISUrl>https://localhost:44301/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>


### PR DESCRIPTION
you may not want to configure ssl on local iisexpress and use an azure website to go faster. In that cas you should be able to open the project. The custom url prevents us from doing so. So I reverted it
